### PR TITLE
Rename methods FromSecret to FromApp

### DIFF
--- a/key.go
+++ b/key.go
@@ -1,0 +1,13 @@
+package kubeconfig
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
+)
+
+func secretName(app v1alpha1.App) string {
+	return app.Spec.KubeConfig.Secret.Name
+}
+
+func secretNamespace(app v1alpha1.App) string {
+	return app.Spec.KubeConfig.Secret.Namespace
+}

--- a/kubeconfig.go
+++ b/kubeconfig.go
@@ -13,14 +13,16 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// Config represents the configuration used to create a new kubeconfig library instance.
+// Config represents the configuration used to create a new kubeconfig library
+// instance.
 type Config struct {
 	G8sClient versioned.Interface
 	Logger    micrologger.Logger
 	K8sClient kubernetes.Interface
 }
 
-// KubeConfig provides functionality for connecting to tenant clusters based on the specified secret information.
+// KubeConfig provides functionality for connecting to remote clusters based on
+// the specified kubeconfig.
 type KubeConfig struct {
 	g8sClient versioned.Interface
 	logger    micrologger.Logger
@@ -91,6 +93,7 @@ func (k KubeConfig) NewK8sClientForApp(ctx context.Context, app v1alpha1.App) (k
 	if err != nil {
 		return nil, err
 	}
+
 	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeConfig)
 	if err != nil {
 		return nil, err

--- a/kubeconfig.go
+++ b/kubeconfig.go
@@ -122,11 +122,3 @@ func (k KubeConfig) getKubeConfigFromSecret(ctx context.Context, secretName, sec
 		return nil, notFoundError
 	}
 }
-
-func secretName(app v1alpha1.App) string {
-	return app.Spec.KubeConfig.Secret.Name
-}
-
-func secretNamespace(app v1alpha1.App) string {
-	return app.Spec.KubeConfig.Secret.Namespace
-}

--- a/kubeconfig.go
+++ b/kubeconfig.go
@@ -3,6 +3,7 @@ package kubeconfig
 import (
 	"context"
 
+	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -14,18 +15,23 @@ import (
 
 // Config represents the configuration used to create a new kubeconfig library instance.
 type Config struct {
+	G8sClient versioned.Interface
 	Logger    micrologger.Logger
 	K8sClient kubernetes.Interface
 }
 
 // KubeConfig provides functionality for connecting to tenant clusters based on the specified secret information.
 type KubeConfig struct {
+	g8sClient versioned.Interface
 	logger    micrologger.Logger
 	k8sClient kubernetes.Interface
 }
 
 // New creates a new KubeConfig service.
 func New(config Config) (*KubeConfig, error) {
+	if config.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
+	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
@@ -34,6 +40,7 @@ func New(config Config) (*KubeConfig, error) {
 	}
 
 	g := &KubeConfig{
+		g8sClient: config.G8sClient,
 		logger:    config.Logger,
 		k8sClient: config.K8sClient,
 	}
@@ -41,9 +48,18 @@ func New(config Config) (*KubeConfig, error) {
 	return g, nil
 }
 
-// NewG8sClientFromSecret returns a generated clientset based on the kubeconfig stored in a secret.
-func (k KubeConfig) NewG8sClientFromSecret(ctx context.Context, secretName, secretNamespace string) (versioned.Interface, error) {
-	kubeConfig, err := k.getKubeConfigFromSecret(ctx, secretName, secretNamespace)
+// NewG8sClientFromApp returns a generated clientset for the cluster configured
+// in the kubeconfig section of the app CR. If this is empty a clientset for
+// the current cluster is returned.
+func (k KubeConfig) NewG8sClientFromApp(ctx context.Context, app v1alpha1.App) (versioned.Interface, error) {
+	secretName := secretName(app)
+
+	// KubeConfig is not configured so connect to current cluster.
+	if secretName == "" {
+		return k.g8sClient, nil
+	}
+
+	kubeConfig, err := k.getKubeConfigFromSecret(ctx, secretName, secretNamespace(app))
 	if err != nil {
 		return nil, err
 	}
@@ -60,9 +76,18 @@ func (k KubeConfig) NewG8sClientFromSecret(ctx context.Context, secretName, secr
 	return client, nil
 }
 
-// NewK8sClientFromSecret returns a Kubernetes clientset based on the kubeconfig stored in a secret.
-func (k KubeConfig) NewK8sClientFromSecret(ctx context.Context, secretName, secretNamespace string) (kubernetes.Interface, error) {
-	kubeConfig, err := k.getKubeConfigFromSecret(ctx, secretName, secretNamespace)
+// NewK8sClientFromApp returns a Kubernetes clientset for the cluster configured
+// in the kubeconfig section of the app CR. If this is empty a clientset for
+// the current cluster is returned.
+func (k KubeConfig) NewK8sClientFromApp(ctx context.Context, app v1alpha1.App) (kubernetes.Interface, error) {
+	secretName := secretName(app)
+
+	// KubeConfig is not configured so connect to current cluster.
+	if secretName == "" {
+		return k.k8sClient, nil
+	}
+
+	kubeConfig, err := k.getKubeConfigFromSecret(ctx, secretName, secretNamespace(app))
 	if err != nil {
 		return nil, err
 	}
@@ -93,4 +118,12 @@ func (k KubeConfig) getKubeConfigFromSecret(ctx context.Context, secretName, sec
 	} else {
 		return nil, notFoundError
 	}
+}
+
+func secretName(app v1alpha1.App) string {
+	return app.Spec.KubeConfig.Secret.Name
+}
+
+func secretNamespace(app v1alpha1.App) string {
+	return app.Spec.KubeConfig.Secret.Namespace
 }

--- a/kubeconfig.go
+++ b/kubeconfig.go
@@ -48,10 +48,10 @@ func New(config Config) (*KubeConfig, error) {
 	return g, nil
 }
 
-// NewG8sClientFromApp returns a generated clientset for the cluster configured
+// NewG8sClientForApp returns a generated clientset for the cluster configured
 // in the kubeconfig section of the app CR. If this is empty a clientset for
 // the current cluster is returned.
-func (k KubeConfig) NewG8sClientFromApp(ctx context.Context, app v1alpha1.App) (versioned.Interface, error) {
+func (k KubeConfig) NewG8sClientForApp(ctx context.Context, app v1alpha1.App) (versioned.Interface, error) {
 	secretName := secretName(app)
 
 	// KubeConfig is not configured so connect to current cluster.
@@ -76,10 +76,10 @@ func (k KubeConfig) NewG8sClientFromApp(ctx context.Context, app v1alpha1.App) (
 	return client, nil
 }
 
-// NewK8sClientFromApp returns a Kubernetes clientset for the cluster configured
+// NewK8sClientForApp returns a Kubernetes clientset for the cluster configured
 // in the kubeconfig section of the app CR. If this is empty a clientset for
 // the current cluster is returned.
-func (k KubeConfig) NewK8sClientFromApp(ctx context.Context, app v1alpha1.App) (kubernetes.Interface, error) {
+func (k KubeConfig) NewK8sClientForApp(ctx context.Context, app v1alpha1.App) (kubernetes.Interface, error) {
 	secretName := secretName(app)
 
 	// KubeConfig is not configured so connect to current cluster.

--- a/kubeconfigtest/kubeconfig.go
+++ b/kubeconfigtest/kubeconfig.go
@@ -1,0 +1,51 @@
+package kubeconfigtest
+
+import (
+	"context"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/kubeconfig"
+	"k8s.io/client-go/kubernetes"
+)
+
+type Config struct {
+	G8sClient             versioned.Interface
+	G8sClientFromAppError error
+	K8sClient             kubernetes.Interface
+	K8sClientFromAppError error
+}
+
+type KubeConfig struct {
+	g8sClient             versioned.Interface
+	g8sClientFromAppError error
+	k8sClient             kubernetes.Interface
+	k8sClientFromAppError error
+}
+
+func New(config Config) kubeconfig.Interface {
+	k := &KubeConfig{
+		g8sClient:             config.G8sClient,
+		g8sClientFromAppError: config.G8sClientFromAppError,
+		k8sClient:             config.K8sClient,
+		k8sClientFromAppError: config.K8sClientFromAppError,
+	}
+
+	return k
+}
+
+func (k *KubeConfig) NewG8sClientFromApp(ctx context.Context, app v1alpha1.App) (versioned.Interface, error) {
+	if k.g8sClientFromAppError != nil {
+		return nil, k.g8sClientFromAppError
+	}
+
+	return k.g8sClient, nil
+}
+
+func (k *KubeConfig) NewK8sClientFromApp(ctx context.Context, app v1alpha1.App) (kubernetes.Interface, error) {
+	if k.k8sClientFromAppError != nil {
+		return nil, k.k8sClientFromAppError
+	}
+
+	return k.k8sClient, nil
+}

--- a/kubeconfigtest/kubeconfig.go
+++ b/kubeconfigtest/kubeconfig.go
@@ -34,7 +34,7 @@ func New(config Config) kubeconfig.Interface {
 	return k
 }
 
-func (k *KubeConfig) NewG8sClientFromApp(ctx context.Context, app v1alpha1.App) (versioned.Interface, error) {
+func (k *KubeConfig) NewG8sClientForApp(ctx context.Context, app v1alpha1.App) (versioned.Interface, error) {
 	if k.g8sClientFromAppError != nil {
 		return nil, k.g8sClientFromAppError
 	}
@@ -42,7 +42,7 @@ func (k *KubeConfig) NewG8sClientFromApp(ctx context.Context, app v1alpha1.App) 
 	return k.g8sClient, nil
 }
 
-func (k *KubeConfig) NewK8sClientFromApp(ctx context.Context, app v1alpha1.App) (kubernetes.Interface, error) {
+func (k *KubeConfig) NewK8sClientForApp(ctx context.Context, app v1alpha1.App) (kubernetes.Interface, error) {
 	if k.k8sClientFromAppError != nil {
 		return nil, k.k8sClientFromAppError
 	}

--- a/kubeconfigtest/kubeconfig_test.go
+++ b/kubeconfigtest/kubeconfig_test.go
@@ -1,0 +1,8 @@
+package kubeconfigtest
+
+import "testing"
+
+func Test_New(t *testing.T) {
+	// Test that New doesn't panic and kubeconfig.Interface is implemented.
+	New(Config{})
+}

--- a/spec.go
+++ b/spec.go
@@ -3,13 +3,19 @@ package kubeconfig
 import (
 	"context"
 
+	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	"k8s.io/client-go/kubernetes"
 )
 
 type Interface interface {
-	// NewG8sClientFromSecret returns a generated clientset based on the kubeconfig stored in a secret.
-	NewG8sClientFromSecret(ctx context.Context, secretName, secretNamespace string) (versioned.Interface, error)
-	// NewK8sClientFromSecret returns a Kubernetes clientset based on the kubeconfig stored in a secret.
-	NewK8sClientFromSecret(ctx context.Context, secretName, secretNamespace string) (kubernetes.Interface, error)
+	// NewG8sClientFromApp returns a generated clientset for the cluster configured
+	// in the kubeconfig section of the app CR. If this is empty a clientset for
+	// the current cluster is returned.
+	NewG8sClientFromApp(ctx context.Context, app v1alpha1.App) (versioned.Interface, error)
+
+	// NewK8sClientFromApp returns a Kubernetes clientset for the cluster configured
+	// in the kubeconfig section of the app CR. If this is empty a clientset for
+	// the current cluster is returned.
+	NewK8sClientFromApp(ctx context.Context, app v1alpha1.App) (kubernetes.Interface, error)
 }

--- a/spec.go
+++ b/spec.go
@@ -9,13 +9,13 @@ import (
 )
 
 type Interface interface {
-	// NewG8sClientFromApp returns a generated clientset for the cluster configured
+	// NewG8sClientForApp returns a generated clientset for the cluster configured
 	// in the kubeconfig section of the app CR. If this is empty a clientset for
 	// the current cluster is returned.
-	NewG8sClientFromApp(ctx context.Context, app v1alpha1.App) (versioned.Interface, error)
+	NewG8sClientForApp(ctx context.Context, app v1alpha1.App) (versioned.Interface, error)
 
-	// NewK8sClientFromApp returns a Kubernetes clientset for the cluster configured
+	// NewK8sClientForApp returns a Kubernetes clientset for the cluster configured
 	// in the kubeconfig section of the app CR. If this is empty a clientset for
 	// the current cluster is returned.
-	NewK8sClientFromApp(ctx context.Context, app v1alpha1.App) (kubernetes.Interface, error)
+	NewK8sClientForApp(ctx context.Context, app v1alpha1.App) (kubernetes.Interface, error)
 }


### PR DESCRIPTION
Renames `NewG8sClientFromSecret` to `NewG8sClientForApp` and `NewK8sClientFromSecret` to `NewK8sClientForApp`.

- This makes the library much easier to use in `app-operator`.
- The library already needs to know about `apiextensions` because it returns a versioned clientset.
- Lastly adds the `kubeconfigtest` package to simplify the unit tests in `app-operator`.

See https://github.com/giantswarm/app-operator/pull/25.