### PR TITLE
Add new rest config method

### DIFF
--- a/kubeconfig.go
+++ b/kubeconfig.go
@@ -114,7 +114,7 @@ func (k *KubeConfig) NewRESTConfigForApp(ctx context.Context, app v1alpha1.App) 
 func (k *KubeConfig) getKubeConfigFromSecret(ctx context.Context, secretName, secretNamespace string) ([]byte, error) {
 	secret, err := k.k8sClient.CoreV1().Secrets(secretNamespace).Get(secretName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
-		return nil, microerror.Maskf(err, fmt.Sprintf("can't find the secretName: %#q, ns: %#q", secretName, secretNamespace), notFoundError)
+		return nil, microerror.Maskf(notFoundError, "Secret %#q in Namespace %#q", secretName, secretNamespace)
 	} else if _, isStatus := err.(*errors.StatusError); isStatus {
 		return nil, microerror.Mask(err)
 	} else if err != nil {

--- a/kubeconfig.go
+++ b/kubeconfig.go
@@ -123,6 +123,6 @@ func (k *KubeConfig) getKubeConfigFromSecret(ctx context.Context, secretName, se
 	if bytes, ok := secret.Data["kubeConfig"]; ok {
 		return bytes, nil
 	} else {
-		return nil, notFoundError
+		return nil, microerror.Mask(notFoundError)
 	}
 }

--- a/kubeconfig.go
+++ b/kubeconfig.go
@@ -2,7 +2,6 @@ package kubeconfig
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"

--- a/kubeconfig.go
+++ b/kubeconfig.go
@@ -123,6 +123,6 @@ func (k *KubeConfig) getKubeConfigFromSecret(ctx context.Context, secretName, se
 	if bytes, ok := secret.Data["kubeConfig"]; ok {
 		return bytes, nil
 	} else {
-		return nil, microerror.Mask(notFoundError)
+		return nil, microerror.Maskf(notFoundError, "Secret %#q in Namespace %#q does not have kubeConfig key in its data", secretName, secretNamespace)
 	}
 }

--- a/kubeconfig.go
+++ b/kubeconfig.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -55,16 +55,13 @@ func New(config Config) (*KubeConfig, error) {
 // NewG8sClientForApp returns a generated clientset for the cluster configured
 // in the kubeconfig section of the app CR. If this is empty a clientset for
 // the current cluster is returned.
-func (k KubeConfig) NewG8sClientForApp(ctx context.Context, app v1alpha1.App) (versioned.Interface, error) {
-	secretName := secretName(app)
-	secretNamespace := secretNamespace(app)
-
+func (k *KubeConfig) NewG8sClientForApp(ctx context.Context, app v1alpha1.App) (versioned.Interface, error) {
 	// KubeConfig is not configured so connect to current cluster.
-	if secretName == "" {
+	if secretName(app) != "" {
 		return k.g8sClient, nil
 	}
 
-	restConfig, err := k.NewRESTConfigForApp(ctx, secretName, secretNamespace)
+	restConfig, err := k.NewRESTConfigForApp(ctx, app)
 	if err != nil {
 		return nil, err
 	}
@@ -79,16 +76,13 @@ func (k KubeConfig) NewG8sClientForApp(ctx context.Context, app v1alpha1.App) (v
 // NewK8sClientForApp returns a Kubernetes clientset for the cluster configured
 // in the kubeconfig section of the app CR. If this is empty a clientset for
 // the current cluster is returned.
-func (k KubeConfig) NewK8sClientForApp(ctx context.Context, app v1alpha1.App) (kubernetes.Interface, error) {
-	secretName := secretName(app)
-	secretNamespace := secretNamespace(app)
-
+func (k *KubeConfig) NewK8sClientForApp(ctx context.Context, app v1alpha1.App) (kubernetes.Interface, error) {
 	// KubeConfig is not configured so connect to current cluster.
-	if secretName == "" {
+	if secretName(app) == "" {
 		return k.k8sClient, nil
 	}
 
-	restConfig, err := k.NewRESTConfigForApp(ctx, secretName, secretNamespace)
+	restConfig, err := k.NewRESTConfigForApp(ctx, app)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -100,7 +94,10 @@ func (k KubeConfig) NewK8sClientForApp(ctx context.Context, app v1alpha1.App) (k
 	return client, nil
 }
 
-func (k KubeConfig) NewRESTConfigForApp(ctx context.Context, secretName, secretNamespace string) (*restclient.Config, error) {
+func (k *KubeConfig) NewRESTConfigForApp(ctx context.Context, app v1alpha1.App) (*rest.Config, error) {
+	secretName := secretName(app)
+	secretNamespace := secretNamespace(app)
+
 	kubeConfig, err := k.getKubeConfigFromSecret(ctx, secretName, secretNamespace)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -114,7 +111,7 @@ func (k KubeConfig) NewRESTConfigForApp(ctx context.Context, secretName, secretN
 }
 
 // getKubeConfigFromSecret returns KubeConfig bytes based on the specified secret information.
-func (k KubeConfig) getKubeConfigFromSecret(ctx context.Context, secretName, secretNamespace string) ([]byte, error) {
+func (k *KubeConfig) getKubeConfigFromSecret(ctx context.Context, secretName, secretNamespace string) ([]byte, error) {
 	secret, err := k.k8sClient.CoreV1().Secrets(secretNamespace).Get(secretName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return nil, microerror.Maskf(err, fmt.Sprintf("can't find the secretName: %#q, ns: %#q", secretName, secretNamespace), notFoundError)

--- a/kubeconfig.go
+++ b/kubeconfig.go
@@ -63,12 +63,12 @@ func (k *KubeConfig) NewG8sClientForApp(ctx context.Context, app v1alpha1.App) (
 
 	restConfig, err := k.NewRESTConfigForApp(ctx, app)
 	if err != nil {
-		return nil, err
+		return nil, microerror.Mask(err)
 	}
 
 	client, err := versioned.NewForConfig(restConfig)
 	if err != nil {
-		return nil, err
+		return nil, microerror.Mask(err)
 	}
 	return client, nil
 }
@@ -89,7 +89,7 @@ func (k *KubeConfig) NewK8sClientForApp(ctx context.Context, app v1alpha1.App) (
 
 	client, err := kubernetes.NewForConfig(restConfig)
 	if err != nil {
-		return nil, err
+		return nil, microerror.Mask(err)
 	}
 	return client, nil
 }

--- a/kubeconfig_test.go
+++ b/kubeconfig_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger/microloggertest"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -32,7 +31,7 @@ func TestKubeConfig_getRESTConfigFromSecret(t *testing.T) {
 					},
 				},
 			},
-			errorMatcher: errors.IsNotFound,
+			errorMatcher: IsNotFoundError,
 		},
 		{
 			name: "case 2: no kubeconfig found",


### PR DESCRIPTION
- We figured that out we need to get `RESTConfig` from tenant cluster so we can create a CRD client. 