### PR TITLE
Moving out two functions from spec which do not require a config.

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,0 +1,24 @@
+package kubeconfig
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/client-go/kubernetes"
+)
+
+// Config represents the configuration used to create a new kubeconfig library
+// instance.
+type Config struct {
+	Logger    micrologger.Logger
+	K8sClient kubernetes.Interface
+}
+
+func (c *Config) Validate() error {
+	if c.Logger == nil {
+		return microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", c)
+	}
+	if c.K8sClient == nil {
+		return microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", c)
+	}
+	return nil
+}

--- a/kubeconfig.go
+++ b/kubeconfig.go
@@ -31,20 +31,11 @@ type KubeConfig struct {
 }
 
 // New creates a new KubeConfig service.
-func New(config Config) (*KubeConfig, error) {
-	if config.Logger == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
-	}
-	if config.K8sClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
-	}
-
-	g := &KubeConfig{
+func New(config Config) *KubeConfig {
+	return &KubeConfig{
 		logger:    config.Logger,
 		k8sClient: config.K8sClient,
 	}
-
-	return g, nil
 }
 
 func (k *KubeConfig) NewKubeConfigForRESTConfig(config *rest.Config, clusterName, namespace string) ([]byte, error) {

--- a/kubeconfig.go
+++ b/kubeconfig.go
@@ -38,7 +38,26 @@ func New(config Config) (*KubeConfig, error) {
 	return g, nil
 }
 
-func (k *KubeConfig) NewKubeConfigForRESTConfig(ctx context.Context, config *rest.Config, clusterName, namespace string) ([]byte, error) {
+// NewRESTConfigForApp returns a Kubernetes REST config for the cluster
+// configured in the kubeconfig section of the app CR.
+func (k *KubeConfig) NewRESTConfigForApp(ctx context.Context, app v1alpha1.App) (*rest.Config, error) {
+	secretName := secretName(app)
+	secretNamespace := secretNamespace(app)
+
+	kubeConfig, err := k.getKubeConfigFromSecret(ctx, secretName, secretNamespace)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeConfig)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	return restConfig, nil
+}
+
+// NewKubeConfigForRESTConfig returns a kubeConfig bytes for the given REST Config.
+func NewKubeConfigForRESTConfig(ctx context.Context, config *rest.Config, clusterName, namespace string) ([]byte, error) {
 	if config == nil {
 		return nil, microerror.Maskf(executionFailedError, "config must not be empty")
 	}
@@ -87,25 +106,8 @@ func (k *KubeConfig) NewKubeConfigForRESTConfig(ctx context.Context, config *res
 	return bytes, nil
 }
 
-// NewRESTConfigForApp returns a Kubernetes REST config for the cluster
-// configured in the kubeconfig section of the app CR.
-func (k *KubeConfig) NewRESTConfigForApp(ctx context.Context, app v1alpha1.App) (*rest.Config, error) {
-	secretName := secretName(app)
-	secretNamespace := secretNamespace(app)
-
-	kubeConfig, err := k.getKubeConfigFromSecret(ctx, secretName, secretNamespace)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeConfig)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-	return restConfig, nil
-}
-
-func (k *KubeConfig) NewRESTConfigForKubeConfig(ctx context.Context, kubeConfig []byte) (*rest.Config, error) {
+// NewRESTConfigForKubeConfig returns a REST Config for the given KubeConfigValue.
+func NewRESTConfigForKubeConfig(ctx context.Context, kubeConfig []byte) (*rest.Config, error) {
 	restConfig, err := clientcmd.RESTConfigFromKubeConfig(kubeConfig)
 	if err != nil {
 		return nil, microerror.Mask(err)

--- a/kubeconfig_test.go
+++ b/kubeconfig_test.go
@@ -2,6 +2,7 @@ package kubeconfig
 
 import (
 	"bytes"
+	"context"
 	"reflect"
 	"testing"
 
@@ -304,7 +305,7 @@ func Test_KubeConfig_NewKubeConfigForRESTConfig(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			kubeConfigBytes, err := k.NewKubeConfigForRESTConfig(tc.input, "test-cluster-name", "")
+			kubeConfigBytes, err := k.NewKubeConfigForRESTConfig(context.Background(), tc.input, "test-cluster-name", "")
 			if err != nil {
 				t.Fatalf("expect nil got %#v", microerror.Mask(err))
 			}

--- a/kubeconfig_test.go
+++ b/kubeconfig_test.go
@@ -297,15 +297,11 @@ func Test_KubeConfig_NewKubeConfigForRESTConfig(t *testing.T) {
 			},
 		},
 	}
-	k := KubeConfig{
-		logger:    microloggertest.New(),
-		k8sClient: fake.NewSimpleClientset(),
-	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			kubeConfigBytes, err := k.NewKubeConfigForRESTConfig(context.Background(), tc.input, "test-cluster-name", "")
+			kubeConfigBytes, err := NewKubeConfigForRESTConfig(context.Background(), tc.input, "test-cluster-name", "")
 			if err != nil {
 				t.Fatalf("expect nil got %#v", microerror.Mask(err))
 			}

--- a/kubeconfig_test.go
+++ b/kubeconfig_test.go
@@ -2,7 +2,6 @@ package kubeconfig
 
 import (
 	"bytes"
-	"context"
 	"reflect"
 	"testing"
 
@@ -305,7 +304,7 @@ func Test_KubeConfig_NewKubeConfigForRESTConfig(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			kubeConfigBytes, err := k.NewKubeConfigForRESTConfig(context.Background(), tc.input, "test-cluster-name", "")
+			kubeConfigBytes, err := k.NewKubeConfigForRESTConfig(tc.input, "test-cluster-name", "")
 			if err != nil {
 				t.Fatalf("expect nil got %#v", microerror.Mask(err))
 			}

--- a/kubeconfigtest/kubeconfig.go
+++ b/kubeconfigtest/kubeconfig.go
@@ -34,11 +34,3 @@ func (k *KubeConfig) NewRESTConfigForApp(ctx context.Context, app v1alpha1.App) 
 
 	return &k.restConfig, nil
 }
-
-func (k *KubeConfig) NewKubeConfigForRESTConfig(ctx context.Context, config *rest.Config, clusterName, namespace string) ([]byte, error) {
-	return []byte(""), nil
-}
-
-func (k *KubeConfig) NewRESTConfigForKubeConfig(ctx context.Context, kubeConfig []byte) (*rest.Config, error) {
-	return &rest.Config{}, nil
-}

--- a/kubeconfigtest/kubeconfig.go
+++ b/kubeconfigtest/kubeconfig.go
@@ -35,10 +35,10 @@ func (k *KubeConfig) NewRESTConfigForApp(ctx context.Context, app v1alpha1.App) 
 	return &k.restConfig, nil
 }
 
-func (k *KubeConfig) NewKubeConfigForRESTConfig(config *rest.Config, clusterName, namespace string) ([]byte, error) {
+func (k *KubeConfig) NewKubeConfigForRESTConfig(ctx context.Context, config *rest.Config, clusterName, namespace string) ([]byte, error) {
 	return []byte(""), nil
 }
 
-func (k *KubeConfig) NewRESTConfigForKubeConfig(kubeConfig []byte) (*rest.Config, error) {
+func (k *KubeConfig) NewRESTConfigForKubeConfig(ctx context.Context, kubeConfig []byte) (*rest.Config, error) {
 	return &rest.Config{}, nil
 }

--- a/kubeconfigtest/kubeconfig.go
+++ b/kubeconfigtest/kubeconfig.go
@@ -35,10 +35,10 @@ func (k *KubeConfig) NewRESTConfigForApp(ctx context.Context, app v1alpha1.App) 
 	return &k.restConfig, nil
 }
 
-func (k *KubeConfig) NewKubeConfigForRESTConfig(ctx context.Context, config *rest.Config, clusterName, namespace string) ([]byte, error) {
+func (k *KubeConfig) NewKubeConfigForRESTConfig(config *rest.Config, clusterName, namespace string) ([]byte, error) {
 	return []byte(""), nil
 }
 
-func (k *KubeConfig) NewRESTConfigForKubeConfig(ctx context.Context, kubeConfig []byte) (*rest.Config, error) {
+func (k *KubeConfig) NewRESTConfigForKubeConfig(kubeConfig []byte) (*rest.Config, error) {
 	return &rest.Config{}, nil
 }

--- a/spec.go
+++ b/spec.go
@@ -11,8 +11,4 @@ type Interface interface {
 	// NewRESTConfigForApp returns a Kubernetes REST Config for the cluster configured
 	// in the kubeconfig section of the app CR.
 	NewRESTConfigForApp(ctx context.Context, app v1alpha1.App) (*rest.Config, error)
-	// NewKubeConfigForRESTConfig returns a kubeConfig bytes for the given REST Config.
-	NewKubeConfigForRESTConfig(ctx context.Context, config *rest.Config, clusterName, namespace string) ([]byte, error)
-	// NewRESTConfigForKubeConfig returns a REST Config for the given KubeConfigValue.
-	NewRESTConfigForKubeConfig(ctx context.Context, kubeConfig []byte) (*rest.Config, error)
 }

--- a/spec.go
+++ b/spec.go
@@ -12,7 +12,7 @@ type Interface interface {
 	// in the kubeconfig section of the app CR.
 	NewRESTConfigForApp(ctx context.Context, app v1alpha1.App) (*rest.Config, error)
 	// NewKubeConfigForRESTConfig returns a kubeConfig bytes for the given REST Config.
-	NewKubeConfigForRESTConfig(config *rest.Config, clusterName, namespace string) ([]byte, error)
+	NewKubeConfigForRESTConfig(ctx context.Context, config *rest.Config, clusterName, namespace string) ([]byte, error)
 	// NewRESTConfigForKubeConfig returns a REST Config for the given KubeConfigValue.
-	NewRESTConfigForKubeConfig(kubeConfig []byte) (*rest.Config, error)
+	NewRESTConfigForKubeConfig(ctx context.Context, kubeConfig []byte) (*rest.Config, error)
 }

--- a/spec.go
+++ b/spec.go
@@ -12,7 +12,7 @@ type Interface interface {
 	// in the kubeconfig section of the app CR.
 	NewRESTConfigForApp(ctx context.Context, app v1alpha1.App) (*rest.Config, error)
 	// NewKubeConfigForRESTConfig returns a kubeConfig bytes for the given REST Config.
-	NewKubeConfigForRESTConfig(ctx context.Context, config *rest.Config, clusterName, namespace string) ([]byte, error)
+	NewKubeConfigForRESTConfig(config *rest.Config, clusterName, namespace string) ([]byte, error)
 	// NewRESTConfigForKubeConfig returns a REST Config for the given KubeConfigValue.
-	NewRESTConfigForKubeConfig(ctx context.Context, kubeConfig []byte) (*rest.Config, error)
+	NewRESTConfigForKubeConfig(kubeConfig []byte) (*rest.Config, error)
 }


### PR DESCRIPTION
To fix an issue from: https://github.com/giantswarm/gsctl/pull/351