### PR TITLE
secret key

### DIFF
--- a/kubeconfig_test.go
+++ b/kubeconfig_test.go
@@ -85,7 +85,7 @@ func Test_KubeConfig_getRESTConfigFromSecret(t *testing.T) {
 				logger:    microloggertest.New(),
 				k8sClient: fake.NewSimpleClientset(objs...),
 			}
-			_, err := k.getKubeConfigFromSecret(context.TODO(), "kubeconfig-secret-gs", "")
+			_, err := k.getKubeConfigFromSecret(context.TODO(), "kubeconfig-secret-gs", "", "kubeConfig")
 
 			switch {
 			case err != nil && tc.errorMatcher == nil:

--- a/kubeconfigtest/kubeconfig.go
+++ b/kubeconfigtest/kubeconfig.go
@@ -27,7 +27,7 @@ func New(config Config) kubeconfig.Interface {
 	return k
 }
 
-func (k *KubeConfig) NewRESTConfigForApp(ctx context.Context, secretName, secretNamespace string) (*rest.Config, error) {
+func (k *KubeConfig) NewRESTConfigForApp(ctx context.Context, secretName, secretNamespace, secretKey string) (*rest.Config, error) {
 	if k.restConfigFromAppError != nil {
 		return nil, k.restConfigFromAppError
 	}

--- a/spec.go
+++ b/spec.go
@@ -9,5 +9,5 @@ import (
 type Interface interface {
 	// NewRESTConfigForApp returns a Kubernetes REST Config for the cluster configured
 	// in the secrets objects.
-	NewRESTConfigForApp(ctx context.Context, secretName, secretNamespace string) (*rest.Config, error)
+	NewRESTConfigForApp(ctx context.Context, secretName, secretNamespace, secretKey string) (*rest.Config, error)
 }


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/16005

CAPI kubeconfig secret uses `.data.values` to store kubeconfig while giantswarm uses `.data.kubeConfig`. Changing this here so we can fetch kubeconfig from CAPI.